### PR TITLE
Fix errors caused by "invalid handle", use External's Thumbnail if it is not a gif (and also add the title/desc to the main description)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -230,6 +230,6 @@ linters:
     - wastedassign
     - whitespace
     - wrapcheck
-    - wsl
+    # - wsl
     - zerologlint
     - exportloopref

--- a/main.go
+++ b/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"html/template"
@@ -220,13 +219,15 @@ var (
 
 func getProfile(w http.ResponseWriter, r *http.Request) {
 	profileID := r.PathValue("profileID")
+	profileID = strings.ReplaceAll(profileID, "|", "")
 
-	ctx, cancel := context.WithTimeout(r.Context(), time.Minute)
-	defer cancel()
+	// Sometimes the handles will say "invalid handle"
+	// TODO: Create a helper func to resolve handles
+	// https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=[profileID]
 
 	apiURL := "https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=" + profileID
 
-	req, reqErr := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, http.NoBody)
+	req, reqErr := http.NewRequestWithContext(r.Context(), http.MethodGet, apiURL, http.NoBody)
 	if reqErr != nil {
 		errorPage(w, "getProfile: Failed to create request")
 		return
@@ -263,8 +264,9 @@ func getPost(w http.ResponseWriter, r *http.Request) {
 	postID := r.PathValue("postID")
 	postID = strings.ReplaceAll(postID, "|", "")
 
-	ctx, cancel := context.WithTimeout(r.Context(), time.Minute)
-	defer cancel()
+	// Sometimes the handles will say "invalid handle"
+	// TODO: Create a helper func to resolve handles
+	// https://public.api.bsky.app/xrpc/com.atproto.identity.resolveHandle?handle=[profileID]
 
 	if !strings.HasPrefix(profileID, "at://") {
 		profileID = "at://" + profileID
@@ -272,7 +274,7 @@ func getPost(w http.ResponseWriter, r *http.Request) {
 
 	postAPIURL := fmt.Sprintf("https://public.api.bsky.app/xrpc/app.bsky.feed.getPostThread?uri=%s/app.bsky.feed.post/%s", profileID, postID)
 
-	postReq, postReqErr := http.NewRequestWithContext(ctx, http.MethodGet, postAPIURL, http.NoBody)
+	postReq, postReqErr := http.NewRequestWithContext(r.Context(), http.MethodGet, postAPIURL, http.NoBody)
 	if postReqErr != nil {
 		errorPage(w, "getPost: Failed to create request")
 		return

--- a/main.go
+++ b/main.go
@@ -533,7 +533,12 @@ func getPost(w http.ResponseWriter, r *http.Request) {
 				return
 			}
 
-			http.Redirect(w, r, selfData.External.Thumb, http.StatusFound)
+			if selfData.External.Thumb != "" {
+				http.Redirect(w, r, selfData.External.Thumb, http.StatusFound)
+				return
+			}
+
+			errorPage(w, "getPost: No suitable media found")
 			return
 		case bskyEmbedVideo:
 			http.Redirect(w, r, fmt.Sprintf("https://bsky.social/xrpc/com.atproto.sync.getBlob?cid=%s&did=%s", selfData.VideoCID, selfData.VideoDID), http.StatusFound)

--- a/views/post.html
+++ b/views/post.html
@@ -22,9 +22,7 @@
     <meta property="twitter:site" content="@{{.data.Author.Handle}}">
     <meta property="twitter:creator" content="@{{.data.Author.Handle}}">
 
-    <meta property="og:description" content="{{.data.Record.Text}}
-
-{{.data.AddnDesc}}">
+    <meta property="og:description" content="{{.data.Description}}">
 
     {{if eq .data.Type "app.bsky.embed.images#view"}}
         <meta property="twitter:card" content="summary_large_image">
@@ -38,8 +36,13 @@
         {{end}}
     {{else if eq .data.Type "app.bsky.embed.external#view"}}
         <meta property="twitter:card" content="summary_large_image">
-        <meta property="og:image" content="{{.data.External.URI}}">
-        <meta property="twitter:image" content="{{.data.External.URI}}">
+        {{if .data.IsGif}}
+            <meta property="og:image" content="{{.data.External.URI}}">
+            <meta property="twitter:image" content="{{.data.External.URI}}">
+        {{else}}
+            <meta property="og:image" content="{{.data.External.Thumb}}">
+            <meta property="twitter:image" content="{{.data.External.Thumb}}">
+        {{end}}
     {{else if eq .data.Type "app.bsky.embed.video#view"}}
         <meta property="og:video" content="https://bsky.social/xrpc/com.atproto.sync.getBlob?cid={{.data.VideoCID}}&did={{.data.VideoDID}}">
         <meta property="og:video:secure_url" content="https://bsky.social/xrpc/com.atproto.sync.getBlob?cid={{.data.VideoCID}}&did={{.data.VideoDID}}">
@@ -56,7 +59,7 @@
         <meta property="twitter:card" content="summary">
     {{end}}
 
-    <link rel="alternate" type="application/json+oembed" href="https://xbsky.app/oembed?for=post&replies={{.data.ReplyCount}}&reposts={{.data.RepostCount}}&likes={{.data.LikeCount}}&quotes={{.data.QuoteCount}}{{if .data.IsVideo}}&description={{.data.Record.Text | escapePath}}&addndesc={{.data.AddnDesc | escapePath}}{{end}}">
+    <link rel="alternate" type="application/json+oembed" href="https://xbsky.app/oembed?for=post&replies={{.data.ReplyCount}}&reposts={{.data.RepostCount}}&likes={{.data.LikeCount}}&quotes={{.data.QuoteCount}}{{if .data.IsVideo}}&description={{.data.Description | escapePath}}{{end}}">
 </head>
 <body>
     {{if not .isTelegram}}
@@ -66,14 +69,18 @@
         <article>
             <h1><a href="https://bsky.app/profile/{{.data.Author.Handle}}/post/{{.postID}}">{{.data.Author.DisplayName}} (@{{.data.Author.Handle}})</a></h1>
             <p>{{.data.Record.Text}}</p>
-            <p>{{.data.AddnDesc}}</p>
+            <p>{{.data.Description}}</p>
             <p>{{.data.StatsForTG}}</p>
             {{if eq .data.Type "app.bsky.embed.images#view"}}
                 {{range $i, $v := .data.Images}}
                     <img src="{{$v.FullSize}}" alt="{{$v.Alt}}" width="{{$v.AspectRatio.Width}}" height="{{$v.AspectRatio.Height}}">
                 {{end}}
             {{else if eq .data.Type "app.bsky.embed.external#view"}}
-                <img src="{{.data.External.URI}}" alt="{{.data.External.Description}}">
+                {{if .data.IsGif}}
+                    <img src="{{.data.External.URI}}" alt="{{.data.External.Description}}">
+                {{else}}
+                    <img src="{{.data.External.Thumb}}" alt="{{.data.External.Description}}">
+                {{end}}
             {{else if eq .data.Type "app.bsky.embed.video#view"}}
                 <video width="{{.data.AspectRatio.Width}}" height="{{.data.AspectRatio.Height}}" controls>
                     <source src="https://bsky.social/xrpc/com.atproto.sync.getBlob?cid={{.data.VideoCID}}&did={{.data.VideoDID}}" type="video/mp4">

--- a/views/post.html
+++ b/views/post.html
@@ -68,7 +68,6 @@
     {{else}}
         <article>
             <h1><a href="https://bsky.app/profile/{{.data.Author.Handle}}/post/{{.postID}}">{{.data.Author.DisplayName}} (@{{.data.Author.Handle}})</a></h1>
-            <p>{{.data.Record.Text}}</p>
             <p>{{.data.Description}}</p>
             <p>{{.data.StatsForTG}}</p>
             {{if eq .data.Type "app.bsky.embed.images#view"}}

--- a/views/post.html
+++ b/views/post.html
@@ -35,11 +35,12 @@
             <meta property="twitter:image:height" content="{{$v.AspectRatio.Height}}">
         {{end}}
     {{else if eq .data.Type "app.bsky.embed.external#view"}}
-        <meta property="twitter:card" content="summary_large_image">
         {{if .data.IsGif}}
+            <meta property="twitter:card" content="summary_large_image">
             <meta property="og:image" content="{{.data.External.URI}}">
             <meta property="twitter:image" content="{{.data.External.URI}}">
-        {{else}}
+        {{else if ne .data.External.Thumb ""}}
+            <meta property="twitter:card" content="summary_large_image">
             <meta property="og:image" content="{{.data.External.Thumb}}">
             <meta property="twitter:image" content="{{.data.External.Thumb}}">
         {{end}}
@@ -77,7 +78,7 @@
             {{else if eq .data.Type "app.bsky.embed.external#view"}}
                 {{if .data.IsGif}}
                     <img src="{{.data.External.URI}}" alt="{{.data.External.Description}}">
-                {{else}}
+                {{else if ne .data.External.Thumb ""}}
                     <img src="{{.data.External.Thumb}}" alt="{{.data.External.Description}}">
                 {{end}}
             {{else if eq .data.Type "app.bsky.embed.video#view"}}


### PR DESCRIPTION
Also includes some fixes:
- Removes unnecessary contexts, and uses r.Context()
- Replaces any spoiler tag (|) in /profile now too.

This'll be merged shortly (in a few hours), though doubt the invalid handles will be an issue by then, but still, just in case it happens again.